### PR TITLE
Some minor changes to enable bundling of drivers

### DIFF
--- a/server/src/AbstractDriver.mjs
+++ b/server/src/AbstractDriver.mjs
@@ -6,10 +6,8 @@ import debounce from 'debounce';
 import chalk from 'chalk';
 import { ClientEvents, DeviceEvents } from './enums.mjs';
 import { error } from './errors.mjs';
+import config from '../config.json' with { type: 'json' };
 
-const config = JSON.parse(
-  await fs.readFile(path.join(import.meta.dirname, '..', 'config.json'))
-);
 
 /**
  * @typedef {Object} DriverConfig - Defaults in config.json, keep synced

--- a/server/src/index.mjs
+++ b/server/src/index.mjs
@@ -53,7 +53,7 @@ async function validateDrivers(filePath) {
     if (!module.default) {
       throw error('MissingDefaultExport', filename);
     }
-    if (!(module.default.prototype instanceof AbstractDriver)) {
+    if (!Object.getPrototypeOf(AbstractDriver).isPrototypeOf(module.default)) {
       throw error('MissingDeviceExtend', filename);
     }
     if (module.default.name in drivers) {


### PR DESCRIPTION
* Use import statement to import config.json in `AbstractDriver`.

* Compare prototypes of `AbstractDriver` and device drivers when validating drivers.